### PR TITLE
feat(mocksessionfromqueryset): extra white spaces in queries removed

### DIFF
--- a/src/custom/response/storedToLive.ts
+++ b/src/custom/response/storedToLive.ts
@@ -17,10 +17,6 @@ export function storedToLive(storedResponse: StoredResponse): LiveResponse {
 
     if (storedResponse.summary) updateStatistics = { ...storedResponse.summary.updateStatistics }
 
-    // if (!returned.hasOwnProperty('summary')) {
-    //     returned.summary = {}
-    // }
-
     if (!returned.summary.hasOwnProperty('counters')) {
         returned.summary.counters = {
         }

--- a/src/custom/session/mockSessionFromQuerySet.ts
+++ b/src/custom/session/mockSessionFromQuerySet.ts
@@ -31,6 +31,10 @@ const errorMessageContentsQueryNotMatched = (params: any, query: string): string
   `the query set provided does not contain the given query:
 ${queryInfo(params, query)}`;
 
+function removeExtraWhite(inString:string):string {
+  return inString.trim().replace(/\s+/g, ' ') 
+}
+
 
 function mockSessionFromQuerySet(querySet: QuerySpec[]): Session {
   const driver = neo4j.driver(
@@ -43,11 +47,12 @@ function mockSessionFromQuerySet(querySet: QuerySpec[]): Session {
 
 
   const fakeSession = driver.session();
+
   const mockRun = async (query: string, params: any) => {
     let queryMatched = false;
     let output: any = '';
     querySet.map((querySpec: QuerySpec) => {
-      if (querySpec.query.trim() === query.trim()) {
+      if (removeExtraWhite(querySpec.query) === removeExtraWhite(query)) {
         queryMatched = true;
         if (!querySpec.params || isSubset(params, querySpec.params)) { // was:  JSON.stringify(querySpec.params) === JSON.stringify(params)
           output = storedToLive(querySpec.output);

--- a/test/custom/mockSessionFromQuerySet.test.ts
+++ b/test/custom/mockSessionFromQuerySet.test.ts
@@ -55,6 +55,8 @@ const expectedOutput2 = {
 }
 const query = 'foo'
 const noParamsQuery = 'noparams'
+const whiteSpaceQuery = '  \nwhite  \r   space   '
+const lessWhiteSpace = 'white space'
 const params = { 'boo': 'bar' }
 const querySet: QuerySpec[] = [
     {
@@ -71,6 +73,10 @@ const querySet: QuerySpec[] = [
         query: noParamsQuery,
         output: expectedOutput2,
     },
+    {
+        query: whiteSpaceQuery,
+        output: expectedOutput,
+    },
 ]
 
 test('mockSessionFromQuerySet returns correct output', async t => {
@@ -84,6 +90,13 @@ test('mockSessionFromQuerySet returns correct output even with extra params', as
     const output = await session.run(query, { 'boo': 'bar', 'extra': 'should be ignored' })
     t.like(stripUpdates(output), stripUpdates(storedToLive(expectedOutput)))
 })
+
+test('mockSessionFromQuerySet extra white space', async t => {
+    const session = mockSessionFromQuerySet(querySet)
+    const output = await session.run(lessWhiteSpace, { 'boo': 'bar', 'extra': 'should be ignored' })
+    t.like(stripUpdates(output), stripUpdates(storedToLive(expectedOutput)))
+})
+
 
 test('mockSessionFromQuerySet takes no params', async t => {
     const session = mockSessionFromQuerySet(querySet)

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,7 +1,8 @@
 module.exports = function (wallaby) {
   return {
     files: [
-      'src/**/*.ts'
+      'src/**/*.ts',
+      'test/data/**.*.ts'
     ],
 
     tests: [


### PR DESCRIPTION
Any sequence of white spaces is now replaced by a single space when comparing queries.  That way,
extra tabs and other spaces introduced into a query set, for instance by lint fixes, will not result
in queries being unmatched.  In cypher, any white space is symantically identical.

fix #30