### PR TITLE
order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,13 +8,13 @@ module.exports = {
     extends: [
         'plugin:@typescript-eslint/recommended',
     ],
-    rules:  {
+    rules: {
         /* ns__custom_start lintRules */
         "no-console": ["error"],
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/ban-types": "off",
-        "@typescript-eslint/no-explicit-any":"off",
+        "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/ban-ts-comment": "off"
         /* ns__custom_end lintRules */
     }

--- a/README.md
+++ b/README.md
@@ -472,6 +472,15 @@ A great way to start is with the tutorials.
 * Start with the [tutorial to create a project and test](https://medium.com/neo4j/how-to-mock-neo4j-calls-in-node-7066c52ac468).
 * Here's a more advanced [tutorial to create a full apollo server](https://medium.com/neo4j/create-a-typescript-apollo-server-and-live-database-with-unit-tests-4ab14ac46654).
 
+# Relevant Package
+
+This package is used by [neo-forte](https://www.npmjs.com/package/neo-forte).  The two complement each other well. The goal of `neo-forte` is to make running your cypher queries in code as simple as it is in a browser.
+
+Both pursue a shared mission: programming with neo4j<a href="#note1" id="note1ref"><sup>2</sup></a> should be really simple!
+
+---
+<a id="note1" href="#note1ref"><sup>2</sup></a> Or any third party service.
+
 # <a name="thumbsup-credits"></a>:thumbsup: Credits
 
 Special thanks goes to some people at [neo4j](https://neo4j.com/) for helping me with this.  

--- a/src/custom/response/storedToLive.ts
+++ b/src/custom/response/storedToLive.ts
@@ -11,7 +11,6 @@ import { dataToLive } from './dataToLive';
 export function storedToLive(storedResponse: StoredResponse): LiveResponse {
     const data = storedToData(storedResponse)
     const returned = dataToLive(data)
-    
     returned.summary = {...storedResponse.summary}
     let updateStatistics:any = {}
 

--- a/src/custom/session/mockSessionFromQuerySet.ts
+++ b/src/custom/session/mockSessionFromQuerySet.ts
@@ -50,7 +50,6 @@ function mockSessionFromQuerySet(querySet: QuerySpec[]): Session {
 
   const mockRun = async (query: string, params: any) => {
     let queryMatched = false;
-    let output: any = '';
     // querySet.map((querySpec: QuerySpec) => {
     //   if (removeExtraWhite(querySpec.query) === removeExtraWhite(query)) {
     //     queryMatched = true;

--- a/src/custom/session/mockSessionFromQuerySet.ts
+++ b/src/custom/session/mockSessionFromQuerySet.ts
@@ -31,8 +31,8 @@ const errorMessageContentsQueryNotMatched = (params: any, query: string): string
   `the query set provided does not contain the given query:
 ${queryInfo(params, query)}`;
 
-function removeExtraWhite(inString:string):string {
-  return inString.trim().replace(/\s+/g, ' ') 
+function removeExtraWhite(inString: string): string {
+  return inString.trim().replace(/\s+/g, ' ')
 }
 
 
@@ -51,16 +51,26 @@ function mockSessionFromQuerySet(querySet: QuerySpec[]): Session {
   const mockRun = async (query: string, params: any) => {
     let queryMatched = false;
     let output: any = '';
-    querySet.map((querySpec: QuerySpec) => {
+    // querySet.map((querySpec: QuerySpec) => {
+    //   if (removeExtraWhite(querySpec.query) === removeExtraWhite(query)) {
+    //     queryMatched = true;
+    //     if (!querySpec.params || isSubset(params, querySpec.params)) { // was:  JSON.stringify(querySpec.params) === JSON.stringify(params)
+    //       output = storedToLive(querySpec.output);
+    //     }
+    //   }
+    // });
+
+    for (let index = 0; index < querySet.length; index++) {
+      const querySpec: QuerySpec = querySet[index];
+
       if (removeExtraWhite(querySpec.query) === removeExtraWhite(query)) {
         queryMatched = true;
-        if (!querySpec.params || isSubset(params, querySpec.params)) { // was:  JSON.stringify(querySpec.params) === JSON.stringify(params)
-          output = storedToLive(querySpec.output);
+        if (!querySpec.params || isSubset(params, querySpec.params)) { 
+          return storedToLive(querySpec.output);
         }
       }
-    });
+    }
 
-    if (output !== '') return output;
     const errorMessageMatchedQuery = errorMessageContentsQueryMatched(params, query);
     if (queryMatched) {
       throw new Error(errorMessageMatchedQuery)

--- a/src/custom/types/DatabaseInfo.ts
+++ b/src/custom/types/DatabaseInfo.ts
@@ -1,4 +1,3 @@
-// const temp = require('../../../../node_modules/neo4j-driver/types/driver')
 export interface DatabaseInfo {
   URI: string;
   USER: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export * from './custom/types/DatabaseInfo'
 export * from './custom/types/QuerySpec'
 export * from './custom/types/StoredResponse'
 export * from './custom/types/StoredRecord'
+export * from './custom/types/LiveResponse'
 
 export const mockSessionFromQuerySet = require('./custom/session/mockSessionFromQuerySet')
 export const mockSessionFromFunction = require('./custom/session/mockSessionFromFunction')

--- a/test/custom/mockSessionFromFunction.test.ts
+++ b/test/custom/mockSessionFromFunction.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 const mockSessionFromFunction = require("../../src/custom/session/mockSessionFromFunction")
+// import { mockSessionFromFunction} from "../../src/custom/session/mockSessionFromFunction"
 import {sampleRecordList} from "./data/sampleRecordList";
 import {dataToLive} from "../../src/custom/response/dataToLive";
 

--- a/test/custom/mockSessionFromQuerySet.test.ts
+++ b/test/custom/mockSessionFromQuerySet.test.ts
@@ -53,7 +53,27 @@ const expectedOutput2 = {
             },
         ]
 }
+
+const expectedOutput3 = {
+    records:
+        [
+            {
+                "keys": [
+                    "a"
+                ],
+                "length": 1,
+                "_fields": [
+                    "aValue"
+                ],
+                "_fieldLookup": {
+                    "a": 0
+                }
+            },
+        ]
+}
+
 const query = 'foo'
+const query2 = 'foobaroo'
 const noParamsQuery = 'noparams'
 const whiteSpaceQuery = '  \nwhite  \r   space   '
 const lessWhiteSpace = 'white space'
@@ -65,9 +85,13 @@ const querySet: QuerySpec[] = [
         output: expectedOutput,
     },
     {
-        query: 'foobaroo',
+        query: query2,
         params: { x: 'y' },
         output: expectedOutput,
+    },
+    {
+        query: query2,
+        output: expectedOutput3,
     },
     {
         query: noParamsQuery,
@@ -95,6 +119,19 @@ test('mockSessionFromQuerySet extra white space', async t => {
     const session = mockSessionFromQuerySet(querySet)
     const output = await session.run(lessWhiteSpace, { 'boo': 'bar', 'extra': 'should be ignored' })
     t.like(stripUpdates(output), stripUpdates(storedToLive(expectedOutput)))
+})
+
+test('mockSessionFromQuerySet evaluates in order', async t => {
+    const session = mockSessionFromQuerySet(querySet)
+
+    // this will match the first query result
+    const output = await session.run(query2, { 'x': 'y'})
+    t.like(stripUpdates(output), stripUpdates(storedToLive(expectedOutput)))
+
+    // this will match the second query result
+    const output2 = await session.run(query2, { 'x': 'z'})
+    t.like(stripUpdates(output2), stripUpdates(storedToLive(expectedOutput3)))
+
 })
 
 

--- a/test/custom/server.test.ts
+++ b/test/custom/server.test.ts
@@ -141,8 +141,6 @@ test('spoof simple server deletion', async (t: any) => {
     variables: DELETE_BOOKS_PARAMS,
   });
 
-  console.log(`result.errors=${JSON.stringify(result.errors, null, 2)}`);
-
   t.true(result.errors === undefined);
 
   if (!result.data) throw new Error('no results for deleteBooks')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "target": "es2017"
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "test/**/*"
   ]
 }

--- a/updateNeo4jGraphql.sh
+++ b/updateNeo4jGraphql.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
+  npm i neo4j/graphql#master
+fi


### PR DESCRIPTION
- fix: update storedToLive to have correct summary.counters.updates()
- test: added a test of deletion on a @neo4j/graphql server
- test: added the latest version of @neo4j/graphql
- test: added graphql as a devdependency
- feat(mocksessionfromqueryset): extra white spaces in queries removed
- feat: query set specs execute in order
- test(mocksessionfromqueryset.test.ts): test for evaluation of query specs in order
- docs(readme.md): updated documentation to show order in queryspecs
