### PR TITLE
add disableLossLessIntegers as to createMockSessions

### DIFF
--- a/src/custom/session/mockSessionFromFunction.ts
+++ b/src/custom/session/mockSessionFromFunction.ts
@@ -14,7 +14,9 @@ export function mockSessionFromFunction(mockRun: Function): Session {
         neo4j.auth.basic(
             mockDatabaseInfo.USER,
             mockDatabaseInfo.PASSWORD
-        )
+        ), {
+            disableLosslessIntegers: true,
+          }
     )
     const fakeSession = driver.session()
     fakeSession.run = mockRun

--- a/src/custom/session/mockSessionFromQuerySet.ts
+++ b/src/custom/session/mockSessionFromQuerySet.ts
@@ -42,7 +42,9 @@ function mockSessionFromQuerySet(querySet: QuerySpec[]): Session {
     neo4j.auth.basic(
       mockDatabaseInfo.USER,
       mockDatabaseInfo.PASSWORD,
-    ),
+    ), {
+      disableLosslessIntegers: true,
+    }
   );
 
 


### PR DESCRIPTION
Hi Mr.YizYah i have been using your neo-forgery application and its great, i noticed that the createSession objects currently do not support `disableLosslessIntegers` so i've added the following line to the two classes: 
`{
  disableLosslessIntegers: true,
}`
please Review when you have time, this would be greatly appreciated
